### PR TITLE
Avoid infinite loop on Windows

### DIFF
--- a/bin/_mocha
+++ b/bin/_mocha
@@ -604,8 +604,10 @@ program.compilers.forEach(c => {
 
 function getResolvePaths(dir) {
   const result = [];
-  while (dir.length > 1) {
+  let lastLength = Number.MAX_SAFE_INTEGER;
+  while (dir.length < lastLength) {
     result.push(path.join(dir, 'node_modules'));
+    lastLength = dir.length;
     dir = path.dirname(dir);
   }
   return result;


### PR DESCRIPTION
### Description of the Change

On Windows, the length of the root folder name is not 1 (C:\) unlike Unix-based platforms (/). This causes an infinite loop while traversing folders during startup. Change it to stop iterating as soon as dirname() no longer strips away any component from the path.

### Benefits

It can be used on Windows!